### PR TITLE
Prevent a use to create new applicant details

### DIFF
--- a/app/controllers/applicant_details_controller.rb
+++ b/app/controllers/applicant_details_controller.rb
@@ -29,15 +29,20 @@ class ApplicantDetailsController < ApplicationController
   # POST /applicant_details
   # POST /applicant_details.json
   def create
-    @applicant_detail = current_user.create_applicant_detail(applicant_detail_params)
+    if current_user.applicant_detail.present?
+      flash[:notice] = "Applicant Details exist. Click Edit, if you want to change something."
+      redirect_to(applicant_detail_path(current_user))
+    else
+      @applicant_detail = current_user.create_applicant_detail(applicant_detail_params)
 
-    respond_to do |format|
-      if @applicant_detail.save
-        format.html { redirect_to root_path, notice: 'Applicant detail was successfully created.' }
-        format.json { render :show, status: :created, location: @applicant_detail }
-      else
-        format.html { render :new }
-        format.json { render json: @applicant_detail.errors, status: :unprocessable_entity }
+      respond_to do |format|
+        if @applicant_detail.save
+          format.html { redirect_to root_path, notice: 'Applicant detail was successfully created.' }
+          format.json { render :show, status: :created, location: @applicant_detail }
+        else
+          format.html { render :new }
+          format.json { render json: @applicant_detail.errors, status: :unprocessable_entity }
+        end
       end
     end
   end


### PR DESCRIPTION
Ok, finally I created a pull request.
So, what do you think about this code? 
If a user (for some unknown reason) goes to applicant_details/new URL, fill the form and submit it, he/she will be redirected to the show view with a notice:
<img width="906" alt="Screen Shot 2021-10-14 at 5 58 23 PM" src="https://user-images.githubusercontent.com/56089936/137401307-2713b9c9-a2a4-4438-9849-e3f6c5d1970e.png">
.