### PR TITLE
Lra 212 mmss set active sessions only in drop down when creating course

### DIFF
--- a/app/admin/courses.rb
+++ b/app/admin/courses.rb
@@ -20,11 +20,14 @@ ActiveAdmin.register Course do
   filter :available_spaces, as: :select
   filter :status, as: :select
 
+  scope :current_camp, :default => true, label: "Current Camp Courses"
+  scope :all
+
   form do |f| # This is a formtastic form builder
     f.semantic_errors # shows errors on :base
     # f.inputs           # builds an input field for every attribute
     f.inputs do
-      f.input :camp_occurrence, label: "Session", as: :select, collection: CampOccurrence.order(begin_date: :desc).no_any_session
+      f.input :camp_occurrence, label: "Session", as: :select, collection: CampOccurrence.active.order(begin_date: :desc).no_any_session
       f.input :title
       f.input :available_spaces
       f.input :status, as: :select, collection: course_status

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,6 +18,7 @@ class Course < ApplicationRecord
 
 
   scope :is_open, -> { where(status: "open") }
+  scope :current_camp, -> { where(camp_occurrence_id: CampOccurrence.active) }
 
   def display_name
     "#{self.title} - #{self.camp_occurrence.description}" # or whatever column you want


### PR DESCRIPTION
Active Admin Courses: in a new course form I added active to CampOccurrence collection [CampOccurrence.**active**.order(begin_date: :desc).no_any_session] to display only active sessions.

Also, I added current_camp scope to the Course model and added two scopes to the Active Admin courses index view: [All] and [Current Camp Courses]