### PR TITLE
Lra 427 mmss user creates one applicant detail

### DIFF
--- a/app/models/applicant_detail.rb
+++ b/app/models/applicant_detail.rb
@@ -38,6 +38,8 @@
 class ApplicantDetail < ApplicationRecord
   belongs_to :user, required: true, inverse_of: :applicant_detail
 
+  validates :user_id, uniqueness: true
+
   validates :firstname, presence: true
   validates :lastname, presence: true
   # validates :us_citizen, presence: true

--- a/app/views/applicant_details/_form.html.erb
+++ b/app/views/applicant_details/_form.html.erb
@@ -172,9 +172,9 @@
 
   <div class="actions">
     <% if applicant_detail.new_record? %>
-      <%= form.submit "Register" %>
+      <%= form.submit "Register", data: { disable_with: "Please wait..." } %>
     <% else %>
-      <%= form.submit "Update" %>
+      <%= form.submit "Update", data: { disable_with: "Please wait..." } %>
     <% end %>
   </div>
 <% end %>

--- a/spec/factories/applicant_details.rb
+++ b/spec/factories/applicant_details.rb
@@ -37,34 +37,35 @@
 #
 FactoryBot.define do
   factory :applicant_detail do
-    user
-    firstname { "Chester" }
-    # middlename { "The" }
-    lastname { "Tester" }
-    gender { "Male" }
-    us_citizen { true }
-    demographic { "MyString" }
-    birthdate { "2019-07-22" }
+    association :user
+    firstname { Faker::Name.first_name }
+    middlename { Faker::Name.middle_name }
+    lastname { Faker::Name.last_name }
+    gender { Faker::Gender.binary_type }
+    # us_citizen { Faker::Boolean.boolean }
+    demographic { Faker::Demographic.race }
+    birthdate { Faker::Date.birthday(min_age: 15, max_age: 18) }
     diet_restrictions { "peanuts" }
     shirt_size { "Large" }
-    address1 { "123 Main Street" }
-    # address2 { "MyString" }
-    city { "Saline" }
-    # state { "MyString" }
+    address1 { Faker::Address.street_address }
+    address2 { Faker::Address.secondary_address }
+    city { Faker::Address.city }
+    state { Faker::Address.state_abbr }
     # state_non_us { "MyString" }
-    postalcode { "48896" }
+    postalcode { Faker::Address.zip_code }
     country { "US" }
-    phone { "1234567890" }
-    parentname { "Cheryl Stooge" }
-    parentaddress1 { "123 Main Street" }
-    # parentaddress2 { "MyString" }
-    parentcity { "Saline" }
-    # parentstate { "MyString" }
+    # phone { Faker::PhoneNumber.cell_phone }
+    phone { "123-333-5555" }
+    parentname { Faker::Name.name }
+    parentaddress1 { Faker::Address.street_address }
+    parentaddress2 { Faker::Address.secondary_address }
+    parentcity { Faker::Address.city }
+    parentstate { Faker::Address.state_abbr }
     # parentstate_non_us { "MyString" }
-    parentzip { "48896" }
+    parentzip { Faker::Address.zip_code  }
     parentcountry { "US" }
-    parentphone { "9876543217" }
-    # parentworkphone { "MyString" }
-    parentemail { "cheryl.tester@tester.com" }
+    parentphone { "123-444-5555" }
+    parentworkphone { "123-666-5555" }
+    parentemail { Faker::Internet.email }
   end
 end

--- a/spec/models/applicant_detail_spec.rb
+++ b/spec/models/applicant_detail_spec.rb
@@ -38,5 +38,37 @@
 require 'rails_helper'
 
 RSpec.describe ApplicantDetail, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  context "the Factory" do
+    it 'is valid' do
+      expect(build(:applicant_detail)).to be_valid
+    end
+  end
+
+  context "all required fields are present" do
+    subject { 
+      FactoryBot.create(:user)
+      FactoryBot.create(:applicant_detail) } 
+
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+  end
+
+  context "without first name" do
+    let!(:user) { FactoryBot.create(:user) }
+
+    it 'is not valid' do
+      expect { (FactoryBot.create(:applicant_detail, firstname: "", user: user)) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Firstname can't be blank")
+    end
+  end
+
+  context "prevent to create two ApplicantDetail records for a user (test user uniqueness)" do
+    let!(:user) { FactoryBot.create(:user) }
+    it 'is valid' do
+      appdet1 = FactoryBot.create(:applicant_detail, user: user)
+      expect(appdet1).to be_valid
+      expect { (FactoryBot.create(:applicant_detail, user: user)) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: User has already been taken")
+    end
+  end
 end


### PR DESCRIPTION
Validation was added to applicant_detail model to prevent users to create more than one applicant details record.
I disabled a submit button with the message "Please wait ..."
Some tests were created for the applicamnt_details model.
