### PR TITLE
Handle um assigned uniqnames

### DIFF
--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -15,7 +15,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
                   :room_mate_request, :personal_statement, 
                   :shirt_size, :notes, :application_status, :application_status_updated_on, :campyear,
                   :offer_status, :partner_program, :transcript, :student_packet, 
-                  :application_deadline, :vaccine_record, :covid_test_record,
+                  :application_deadline, :vaccine_record, :covid_test_record, :uniqname,
                   session_assignments_attributes: [:id, :camp_occurrence_id, :_destroy ],
                   course_assignments_attributes: [:id, :course_id, :_destroy ]
 
@@ -49,6 +49,9 @@ ActiveAdmin.register Enrollment, as: "Application" do
     f.semantic_errors *f.object.errors.keys # shows errors on :base
     f.inputs do
      f.input :user_id, as: :select, collection: User.all.order(:email)
+     if application.application_status == 'enrolled'
+      f.input :uniqname
+    end
      f.input :international
      f.input :campyear
      f.input :high_school_name
@@ -186,6 +189,9 @@ ActiveAdmin.register Enrollment, as: "Application" do
   show do
     attributes_table do
       row :user_id do |user| link_to(user.applicant_detail.full_name.titleize, admin_applicant_detail_path(user.applicant_detail)) end
+      if application.application_status == 'enrolled'
+        row :uniqname
+      end
       row :personal_statement
       row :notes
       row :offer_status

--- a/app/views/static_pages/_directions.html.erb
+++ b/app/views/static_pages/_directions.html.erb
@@ -123,6 +123,11 @@
         <p class="direction_notes">
           We look forward to seeing you at the <%= @current_camp_year %> University of Michigan MMSS High School Summer Program.
         </p>
+        <% if @current_enrollment.uniqname.present? %>
+              <p class="m-2">
+                Your University of Michigan uniqname is <strong><%= @current_enrollment.uniqname %></strong>
+              </p>
+        <% end %>
       </div>
     <% else %>
       <div class="m-2">

--- a/db/migrate/20221226143012_add_uniqname_to_enrollment.rb
+++ b/db/migrate/20221226143012_add_uniqname_to_enrollment.rb
@@ -1,0 +1,5 @@
+class AddUniqnameToEnrollment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :enrollments, :uniqname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_15_154325) do
+ActiveRecord::Schema.define(version: 2022_12_26_143012) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "namespace"
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 2022_12_15_154325) do
     t.bigint "course_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "waiting_list", default: false
     t.index ["course_id"], name: "index_course_assignments_on_course_id"
     t.index ["enrollment_id"], name: "index_course_assignments_on_enrollment_id"
   end
@@ -224,6 +225,7 @@ ActiveRecord::Schema.define(version: 2022_12_15_154325) do
     t.integer "campyear"
     t.date "application_deadline"
     t.date "application_status_updated_on"
+    t.string "uniqname"
     t.index ["user_id"], name: "index_enrollments_on_user_id"
   end
 
@@ -353,21 +355,15 @@ ActiveRecord::Schema.define(version: 2022_12_15_154325) do
 
   create_table "travels", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
-    t.string "arrival_transport"
-    t.string "arrival_carrier"
-    t.string "arrival_route_num"
+    t.string "direction"
+    t.string "transport_needed"
+    t.datetime "date"
+    t.string "mode"
+    t.string "carrier"
+    t.string "route_num"
     t.text "note"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.date "arrival_date"
-    t.time "arrival_time"
-    t.string "depart_transport"
-    t.time "depart_route_num"
-    t.date "depart_date"
-    t.time "depart_time"
-    t.string "depart_carrier"
-    t.string "arrival_session"
-    t.string "depart_session"
     t.index ["enrollment_id"], name: "index_travels_on_enrollment_id"
   end
 
@@ -410,4 +406,5 @@ ActiveRecord::Schema.define(version: 2022_12_15_154325) do
   add_foreign_key "session_activities", "enrollments"
   add_foreign_key "session_assignments", "camp_occurrences"
   add_foreign_key "session_assignments", "enrollments"
+  add_foreign_key "travels", "enrollments"
 end


### PR DESCRIPTION
I added a uniqname field to the enrollments table.
I added the uniqname field to active admin enrollment edit and show views.
The admin can add uniqname to an applicant’s enrollment.
Applicants will see their uniqname when they log in to the system.

**A question** - should the system send an email to the applicant after the admin adds a uniqname to the applicant’s enrollment?