### PR TITLE
Fix small things

### DIFF
--- a/app/admin/recuploads.rb
+++ b/app/admin/recuploads.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Recupload do
   form do |f|
     f.semantic_errors
     f.inputs do
-      f.input :recommendation_id, as: :select, collection: Recommendation.all.map { |reccup| [reccup.display_name.downcase, reccup.id]}.sort
+      f.input :recommendation_id, label: "Applicant Name", as: :select, collection: Recommendation.all.map { |reccup| [reccup.applicant_name, reccup.id]}.sort
       f.input :letter
       f.input :recletter, as: :file
       f.input :authorname

--- a/app/controllers/applicant_details_controller.rb
+++ b/app/controllers/applicant_details_controller.rb
@@ -15,6 +15,9 @@ class ApplicantDetailsController < ApplicationController
   # GET /applicant_details/1.json
   def show
     @us_citizen = citizen_status
+    if current_user.enrollments.current_camp_year_applications.present?
+      @current_enrollment = current_user.enrollments.current_camp_year_applications.last
+    end
   end
 
   # GET /applicant_details/new
@@ -24,6 +27,9 @@ class ApplicantDetailsController < ApplicationController
 
   # GET /applicant_details/1/edit
   def edit
+    if current_user.enrollments.current_camp_year_applications.present?
+      @current_enrollment = current_user.enrollments.current_camp_year_applications.last
+    end
   end
 
   # POST /applicant_details

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -29,6 +29,7 @@
 #
 class Enrollment < ApplicationRecord
   after_update :send_offer_letter
+  before_update :if_application_status_changed
   before_update :set_application_deadline
   after_commit :send_enroll_letter, if: :persisted?
   after_commit :send_rejected_letter, if: :persisted?
@@ -202,6 +203,12 @@ class Enrollment < ApplicationRecord
   def set_application_deadline
     if self.session_assignments.present? && self.course_assignments.present?
       self.application_deadline = 30.days.from_now unless self.application_deadline.present?
+    end
+  end
+
+  def if_application_status_changed
+    if self.application_status_changed?
+      self.application_status_updated_on = Date.today
     end
   end
 

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -41,4 +41,8 @@ class Recommendation < ApplicationRecord
     "#{lastname}, #{firstname}"
   end
 
+  def applicant_name
+    self.enrollment.user.applicant_detail.full_name
+  end
+
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,9 @@
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="field">
-        <%= f.label "Email (please use the applicant's email address here, not a parent's email)"%>
+        <p>Email (please use the applicant's email address here, not a parent's email)
+        </p>
+        <%= f.label :email, class: "hidden"%>
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
       </div>
 


### PR DESCRIPTION
- application_status_updated_on field (in the enrollments table) was not updated if an admin changed status manually in the Active Admin Application form - fixed
- in Active Admin Recupload new form, a recommender’s name is replaced with the applicant’s name
- if an applicant (who has an application) goes to applicant_details show/edit view - the sidebox shows only Applicant Details - fixed
- fixed label for the new registration view 