### PR TITLE
Lra 489 mmss how to add students to a course wait list

### DIFF
--- a/app/admin/course_assignments.rb
+++ b/app/admin/course_assignments.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register CourseAssignment do
   #
   # Uncomment all parameters which should be permitted for assignment
   #
-   permit_params :enrollment_id, :course_id
+   permit_params :enrollment_id, :course_id, :wait_list
 
    filter :enrollment_id, as: :select, collection: -> { Enrollment.current_camp_year_applications.map { |enrol| [enrol.display_name.downcase, enrol.id]}.sort}
    filter :course_id, as: :select, collection: Course.where(camp_occurrence_id: CampOccurrence.active).order(camp_occurrence_id: :asc, title: :asc)
@@ -16,6 +16,7 @@ ActiveAdmin.register CourseAssignment do
       f.input :enrollment_id, as: :select, collection: Enrollment.current_camp_year_applications.map { |enrol| [enrol.display_name.downcase, enrol.id]}.sort
       f.input :course_id, label: "Course", as: :select, collection: Course.where(camp_occurrence_id: CampOccurrence.active)
     end
+    f.inputs :wait_list
     f.actions
   end
 
@@ -26,6 +27,7 @@ ActiveAdmin.register CourseAssignment do
     column "Course" do |ca|
       ca.course
     end
+    column :wait_list
     column :created_at
     column :updated_at
   end
@@ -36,6 +38,7 @@ ActiveAdmin.register CourseAssignment do
     row "Course" do |ca|
       ca.course
     end
+    row :wait_list
     row :created_at
     row :updated_at
     end

--- a/app/admin/courses.rb
+++ b/app/admin/courses.rb
@@ -48,6 +48,9 @@ ActiveAdmin.register Course do
     column "Open Spaces" do |op|
       op.available_spaces - CourseAssignment.number_of_assignments(op.id)
     end
+    column "Wait List" do |op|
+      CourseAssignment.wait_list_number(op.id)
+    end
     column :faculty_uniqname
     column :faculty_name
     column :status
@@ -66,12 +69,32 @@ ActiveAdmin.register Course do
       row "Open Spaces" do |op|
         op.available_spaces - CourseAssignment.number_of_assignments(op.id)
       end
+      row "Wait List" do |op|
+        CourseAssignment.wait_list_number(op.id)
+      end
       row :faculty_uniqname
       row :faculty_name
       row :status
       row :created_at
       row :updated_at
     end
+    panel "List of students" do
+      enrollment_ids = CourseAssignment.where(course_id: course).order(:wait_list).pluck(:enrollment_id)
+        students = enrollment_ids.collect { |id| Enrollment.find(id) }
+        if students.present?
+          table_for students do
+            column "Name" do |student| 
+              link_to("#{student.applicant_detail.full_name}", admin_application_path(student))
+            end
+            column "Name" do |student|
+              student.user.email
+            end
+            column :waiting_list do |student|
+              CourseAssignment.find_by(course_id: course, enrollment_id: student).wait_list
+            end
+          end
+        end
+      end
     active_admin_comments
   end
 

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
                   :offer_status, :partner_program, :transcript, :student_packet, 
                   :application_deadline, :vaccine_record, :covid_test_record, :uniqname,
                   session_assignments_attributes: [:id, :camp_occurrence_id, :_destroy ],
-                  course_assignments_attributes: [:id, :course_id, :_destroy ]
+                  course_assignments_attributes: [:id, :course_id, :wait_list, :_destroy ]
 
   scope :current_camp_year_applications, :default => true, label: "Current years Applications"
   scope :all
@@ -118,8 +118,9 @@ ActiveAdmin.register Enrollment, as: "Application" do
                   allow_destroy: true,
                   new_record: true do |a|
                     a.input :course_id, as: :select, collection:
-                    application.course_registrations.order(:camp_occurrence_id).map{|u| ["#{u.title}, #{u.camp_occurrence.description}, 
-                    rank - #{application.course_preferences.find_by(course_id: u.id).ranking}, available - #{u.available_spaces - CourseAssignment.number_of_assignments(u.id)}", u.id]}
+                      application.course_registrations.order(:camp_occurrence_id).map{|u| ["#{u.title}, #{u.camp_occurrence.description}, 
+                      rank - #{application.course_preferences.find_by(course_id: u.id).ranking}, available - #{u.available_spaces - CourseAssignment.number_of_assignments(u.id)}", u.id]}
+                    a.input :wait_list
                   end
     end
     if application.session_assignments.any? and application.course_assignments.any?
@@ -225,6 +226,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
           column "Session" do |item| 
             item.course.camp_occurrence.description 
           end
+          column :wait_list
         end
 
         table_for application.course_preferences do

--- a/app/controllers/course_assignments_controller.rb
+++ b/app/controllers/course_assignments_controller.rb
@@ -4,7 +4,7 @@ class CourseAssignmentsController < InheritedResources::Base
   private
 
     def course_assignment_params
-      params.require(:course_assignment).permit(:enrollment_id, :course_id)
+      params.require(:course_assignment).permit(:enrollment_id, :course_id, :wait_list)
     end
 
 end

--- a/app/controllers/faculties_controller.rb
+++ b/app/controllers/faculties_controller.rb
@@ -10,7 +10,7 @@ class FacultiesController < ApplicationController
 
   def student_list
     @course = Course.find(params[:id])
-    enrollment_ids = CourseAssignment.where(course_id: params[:id]).pluck(:enrollment_id)
+    enrollment_ids = CourseAssignment.where(course_id: params[:id], wait_list: false).pluck(:enrollment_id)
     @students = Enrollment.where(id: enrollment_ids)
   end
 

--- a/app/controllers/session_assignments_controller.rb
+++ b/app/controllers/session_assignments_controller.rb
@@ -32,6 +32,11 @@ class SessionAssignmentsController < ApplicationController
         if @course_assignment.present?
           @course_assignment.destroy
         end
+        # destroy wait_list assignments too (if they exist)
+        waiting_list = CourseAssignment.find_by(enrollment_id: @session_assignment.enrollment_id, course_id: CampOccurrence.find(@session_assignment.camp_occurrence_id).courses.ids, wait_list: true)
+        if waiting_list.present?
+          waiting_list.destroy
+        end
         status_array = SessionAssignment.where(enrollment_id: @current_enrollment).pluck(:offer_status)
         if status_array.count("declined") == status_array.size
           enroll_id = @session_assignment.enrollment_id
@@ -61,7 +66,7 @@ class SessionAssignmentsController < ApplicationController
     end
 
     def set_course_assignment
-       @course_assignment = CourseAssignment.find_by(enrollment_id: @session_assignment.enrollment_id, course_id: CampOccurrence.find(@session_assignment.camp_occurrence_id).courses.ids)
+      @course_assignment = CourseAssignment.find_by(enrollment_id: @session_assignment.enrollment_id, course_id: CampOccurrence.find(@session_assignment.camp_occurrence_id).courses.ids, wait_list: false)
     end
 
     def session_assignment_params

--- a/app/mailers/offer_mailer.rb
+++ b/app/mailers/offer_mailer.rb
@@ -6,7 +6,7 @@ class OfferMailer < ApplicationMailer
     @offer_letter_text = CampConfiguration.active.last.offer_letter
     @application = ApplicantDetail.find_by(user_id: user)
     @enrollment = Enrollment.current_camp_year_applications.find_by(user_id: user)
-    @assigned_courses = @enrollment.course_assignments
+    @assigned_courses = @enrollment.course_assignments.where(wait_list: false)
     @assigned_sessions = @enrollment.session_assignments
     @url = ConstantData::HOST_URL
     @camp_config = CampConfiguration.find_by(active: true)

--- a/app/models/course_assignment.rb
+++ b/app/models/course_assignment.rb
@@ -7,12 +7,14 @@
 #  course_id     :bigint           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  wait_list     :boolean          default(FALSE)
 #
 class CourseAssignment < ApplicationRecord
   belongs_to :enrollment
   belongs_to :course
 
 
-  scope :number_of_assignments, ->(course_id="") {where(course_id: course_id).size}
+  scope :number_of_assignments, ->(course_id="") {where(course_id: course_id, wait_list: false).size}
+  scope :wait_list_number, -> (course_id="") { where(course_id: course_id, wait_list: true).size }
 
 end

--- a/app/views/layouts/_sidebox.html.erb
+++ b/app/views/layouts/_sidebox.html.erb
@@ -119,7 +119,7 @@
               <div>
                 <%= sa.camp_occurrence.display_name %>
                 <div>
-                  <% course_ids = CourseAssignment.where(enrollment_id: current_enrollment).pluck(:course_id) %>
+                  <% course_ids = CourseAssignment.where(enrollment_id: current_enrollment, wait_list: false).pluck(:course_id) %>
                   Course:
                   <% if Course.find_by(id: course_ids, camp_occurrence_id: sa.camp_occurrence_id) %>
                     <%= Course.find_by(id: course_ids, camp_occurrence_id: sa.camp_occurrence_id).title %>
@@ -130,6 +130,15 @@
               </div>
               <% end %>
             <% end %>
+            <div>
+              <% course_ids = CourseAssignment.where(enrollment_id: current_enrollment, wait_list: true).pluck(:course_id) %>
+              <% if course_ids.present? %>
+                <div class="text-xs font-semibold">Wait list courses:</div>
+                <% Course.where(id: course_ids).each do |course| %>
+                  <%= course.display_name %>
+                <% end %>
+              <% end %>
+            </div>
             <hr>
             <h4>Download and return the <br>
               <div class="my-2">

--- a/db/migrate/20230118135603_add_wait_list_to_course_assignment.rb
+++ b/db/migrate/20230118135603_add_wait_list_to_course_assignment.rb
@@ -1,0 +1,5 @@
+class AddWaitListToCourseAssignment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :course_assignments, :wait_list, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_26_143012) do
+ActiveRecord::Schema.define(version: 2023_01_18_135603) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "namespace"
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2022_12_26_143012) do
     t.bigint "course_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "waiting_list", default: false
+    t.boolean "wait_list", default: false
     t.index ["course_id"], name: "index_course_assignments_on_course_id"
     t.index ["enrollment_id"], name: "index_course_assignments_on_enrollment_id"
   end
@@ -355,12 +355,9 @@ ActiveRecord::Schema.define(version: 2022_12_26_143012) do
 
   create_table "travels", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
-    t.string "direction"
-    t.string "transport_needed"
-    t.datetime "date"
-    t.string "mode"
-    t.string "carrier"
-    t.string "route_num"
+    t.string "arrival_transport"
+    t.string "arrival_carrier"
+    t.string "arrival_route_num"
     t.text "note"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/course_assignments.rb
+++ b/spec/factories/course_assignments.rb
@@ -7,6 +7,7 @@
 #  course_id     :bigint           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  wait_list     :boolean          default(FALSE)
 #
 FactoryBot.define do
   factory :course_assignment do

--- a/spec/models/course_assignment_spec.rb
+++ b/spec/models/course_assignment_spec.rb
@@ -7,6 +7,7 @@
 #  course_id     :bigint           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  wait_list     :boolean          default(FALSE)
 #
 require 'rails_helper'
 


### PR DESCRIPTION
I created a pull request because it's much easier to see changes in a pull request than in a branch. You can change the status of the PR if you want.

- wait_list boolean field is added to the course_assignment model (default - false)
- admin can create a course_assignment and mark it wait_list (students are not getting any emails about wait_list course_assignments)
- wait_list field is added to all Active Admin Course Assignment views
- courses index view has a wait_list field
- course show view has a list of students with a wait_list field yes-or-no value
- in the applicant’s sidebox, wait_list courses are displayed if a student accepts an offer for a session with the wait_list course
- if an applicant rejects an offer all course_assignments (including wait_list assignments) are deleted
- faculty see only active students in their courses (no wait_list students)