### PR TITLE
Lra 1021 mmss new student packet upload process

### DIFF
--- a/app/admin/camp_configurations.rb
+++ b/app/admin/camp_configurations.rb
@@ -48,7 +48,7 @@ ActiveAdmin.register CampConfiguration do
      f.input :camper_acceptance_due
      f.input :active
      f.input :offer_letter
-     f.input :student_packet_url
+    #  f.input :student_packet_url
      f.input :application_fee
      f.input :reject_letter
      f.input :waitlist_letter
@@ -66,7 +66,7 @@ ActiveAdmin.register CampConfiguration do
     column :application_materials_due
     column :camper_acceptance_due
     column :active
-    column :student_packet_url
+    # column :student_packet_url
     column "Application Fee" do |af|
       humanized_money_with_symbol(af.application_fee)
     end
@@ -90,7 +90,7 @@ ActiveAdmin.register CampConfiguration do
     row "Wait list Letter Text" do |item|
       item.waitlist_letter
     end
-    row :student_packet_url
+    # row :student_packet_url
     row "Application fee" do |cc|
       humanized_money_with_symbol(cc.application_fee)
     end

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
                   :high_school_state, :high_school_non_us, 
                   :high_school_postalcode, :high_school_country, 
                   :year_in_school, :anticipated_graduation_year, 
-                  :room_mate_request, :personal_statement, 
+                  :room_mate_request, :personal_statement, :camp_doc_form_completed,
                   :shirt_size, :notes, :application_status, :application_status_updated_on, :campyear,
                   :offer_status, :partner_program, :transcript, :student_packet, 
                   :application_deadline, :vaccine_record, :covid_test_record, :uniqname,
@@ -93,6 +93,8 @@ ActiveAdmin.register Enrollment, as: "Application" do
 
       end
      f.input :transcript, as: :file, label: "Update transcript"
+     f.input :camp_doc_form_completed
+
     #  f.input :student_packet, as: :file, label: "Update student_packet"
     #  f.input :vaccine_record, as: :file, label: "Update vaccine_record"
     #  f.input :covid_test_record, as: :file, label: "Update covid_test_record"
@@ -170,6 +172,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
     #     link_to sp.covid_test_record.filename, url_for(sp.covid_test_record)
     #   end
     # end
+    column :camp_doc_form_completed
     column :offer_status
     column :application_deadline
     column :application_status
@@ -202,7 +205,6 @@ ActiveAdmin.register Enrollment, as: "Application" do
       row :application_status
       row :application_status_updated_on
       row :partner_program
-      row :campyear
     end
 
     panel "Session Assignment" do
@@ -214,7 +216,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
 
       table_for application.session_registrations do
         column "User Selected Sessions" do |item| 
-          item.description 
+          item&.description 
         end
       end
     end
@@ -337,6 +339,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
           link_to tr.transcript.filename, url_for(tr.transcript)
         end
       end
+      row :camp_doc_form_completed
       # row :student_packet do |sp|
       #   if sp.student_packet.attached?
       #     link_to sp.student_packet.filename, url_for(sp.student_packet)
@@ -396,6 +399,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
     column :room_mate_request
     column :notes
     column :partner_program
+    column :camp_doc_form_completed
     column "Balance Due" do |app|
       humanized_money_with_symbol(PaymentState.new(app).balance_due / 100)
     end

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -32,7 +32,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
   scope :no_recomendation, group: :missing
   scope :no_letter, group: :missing
   scope :no_payments, group: :missing
-  scope :no_student_packet, group: :missing
+  # scope :no_student_packet, group: :missing
 
   # scope :no_vaccine_record, group: :vaccine
   # scope :no_covid_test_record, group: :vaccine
@@ -75,11 +75,11 @@ ActiveAdmin.register Enrollment, as: "Application" do
             link_to item.transcript.filename, url_for(item.transcript)
           end
         end
-        column "Current Student Packet" do |item| 
-          if item.student_packet.attached?
-            link_to item.student_packet.filename, url_for(item.student_packet)
-          end
-        end
+        # column "Current Student Packet" do |item| 
+        #   if item.student_packet.attached?
+        #     link_to item.student_packet.filename, url_for(item.student_packet)
+        #   end
+        # end
         # column "Vaccine Record" do |item| 
         #   if item.vaccine_record.attached?
         #     link_to item.vaccine_record.filename, url_for(item.vaccine_record)
@@ -93,7 +93,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
 
       end
      f.input :transcript, as: :file, label: "Update transcript"
-     f.input :student_packet, as: :file, label: "Update student_packet"
+    #  f.input :student_packet, as: :file, label: "Update student_packet"
     #  f.input :vaccine_record, as: :file, label: "Update vaccine_record"
     #  f.input :covid_test_record, as: :file, label: "Update covid_test_record"
       hr
@@ -155,11 +155,11 @@ ActiveAdmin.register Enrollment, as: "Application" do
         link_to enroll.transcript.filename, url_for(enroll.transcript)
       end
     end
-    column "Student Packet" do |sp|
-      if sp.student_packet.attached?
-        link_to sp.student_packet.filename, url_for(sp.student_packet)
-      end
-    end
+    # column "Student Packet" do |sp|
+    #   if sp.student_packet.attached?
+    #     link_to sp.student_packet.filename, url_for(sp.student_packet)
+    #   end
+    # end
     # column "Vaccination Record" do |enroll|
     #   if enroll.vaccine_record.attached?
     #     link_to enroll.vaccine_record.filename, url_for(enroll.vaccine_record)
@@ -337,11 +337,11 @@ ActiveAdmin.register Enrollment, as: "Application" do
           link_to tr.transcript.filename, url_for(tr.transcript)
         end
       end
-      row :student_packet do |sp|
-        if sp.student_packet.attached?
-          link_to sp.student_packet.filename, url_for(sp.student_packet)
-        end
-      end
+      # row :student_packet do |sp|
+      #   if sp.student_packet.attached?
+      #     link_to sp.student_packet.filename, url_for(sp.student_packet)
+      #   end
+      # end
       # row :vaccine_record do |tr|
       #   if tr.vaccine_record.attached?
       #     link_to tr.vaccine_record.filename, url_for(tr.vaccine_record)
@@ -381,11 +381,11 @@ ActiveAdmin.register Enrollment, as: "Application" do
         "uploaded"
       end
     end
-    column "Student Packet" do |sp|
-      if sp.student_packet.attached?
-        "uploaded"
-      end
-    end
+    # column "Student Packet" do |sp|
+    #   if sp.student_packet.attached?
+    #     "uploaded"
+    #   end
+    # end
     column :offer_status
     column :application_deadline
     column :application_status

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -216,7 +216,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
 
       table_for application.session_registrations do
         column "User Selected Sessions" do |item| 
-          item&.description 
+          item.description 
         end
       end
     end

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -32,6 +32,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
   scope :no_recomendation, group: :missing
   scope :no_letter, group: :missing
   scope :no_payments, group: :missing
+  scope :no_camp_doc_form
   # scope :no_student_packet, group: :missing
 
   # scope :no_vaccine_record, group: :vaccine

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -58,7 +58,7 @@ class EnrollmentsController < ApplicationController
   def update
     respond_to do |format|
       if @current_enrollment.update(enrollment_params)
-        if @current_enrollment.student_packet.attached? && balance_due == 0
+        if @current_enrollment.camp_doc_form_completed && balance_due == 0
           @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today)
         end
         format.html { redirect_to root_path, notice: 'Application was successfully updated.' }
@@ -164,7 +164,7 @@ class EnrollmentsController < ApplicationController
                           :personal_statement, :shirt_size, :notes,
                           :application_status, :offer_status,
                           :partner_program, :transcript,
-                          :student_packet, :campyear,
+                          :student_packet, :campyear, :camp_doc_form_completed,
                           :vaccine_record, :covid_test_record,
                           registration_activity_ids: [],
                           session_registration_ids: [],

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -40,6 +40,7 @@ class PaymentsController < ApplicationController
       if params['transactionStatus'] != '1'
         redirect_to all_payments_path, alert: "Your payment was not successfull"
       else
+        @current_enrollment.update!(balance_due_cents: balance_due)
         redirect_to all_payments_path, notice: "Your payment was successfully recorded"
       end
     end

--- a/app/controllers/session_assignments_controller.rb
+++ b/app/controllers/session_assignments_controller.rb
@@ -16,7 +16,7 @@ class SessionAssignmentsController < ApplicationController
         status_array = SessionAssignment.where(enrollment_id: @current_enrollment).pluck(:offer_status)
         if status_array.count("accepted") + status_array.count("declined") == status_array.size
           enroll_id = @session_assignment.enrollment_id
-          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today)
+          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today, balance_due_cents: balance_due)
         end
         format.html { redirect_to all_payments_path, notice: 'Session assignment was successfully accepted.' }
         format.json { render :show, status: :ok, location: @session_assignment }
@@ -47,7 +47,7 @@ class SessionAssignmentsController < ApplicationController
           format.json { render :show, status: :ok, location: @session_assignment }
         elsif status_array.count("accepted") + status_array.count("declined") == status_array.size
           enroll_id = @session_assignment.enrollment_id
-          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today)
+          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today, balance_due_cents: balance_due)
           format.html { redirect_to all_payments_path, notice: 'Session assignment was declined.' }
           format.json { render :show, status: :ok, location: @session_assignment }
         else

--- a/app/controllers/session_assignments_controller.rb
+++ b/app/controllers/session_assignments_controller.rb
@@ -16,7 +16,7 @@ class SessionAssignmentsController < ApplicationController
         status_array = SessionAssignment.where(enrollment_id: @current_enrollment).pluck(:offer_status)
         if status_array.count("accepted") + status_array.count("declined") == status_array.size
           enroll_id = @session_assignment.enrollment_id
-          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today, balance_due_cents: balance_due)
+          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today)
         end
         format.html { redirect_to all_payments_path, notice: 'Session assignment was successfully accepted.' }
         format.json { render :show, status: :ok, location: @session_assignment }
@@ -47,7 +47,7 @@ class SessionAssignmentsController < ApplicationController
           format.json { render :show, status: :ok, location: @session_assignment }
         elsif status_array.count("accepted") + status_array.count("declined") == status_array.size
           enroll_id = @session_assignment.enrollment_id
-          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today, balance_due_cents: balance_due)
+          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today)
           format.html { redirect_to all_payments_path, notice: 'Session assignment was declined.' }
           format.json { render :show, status: :ok, location: @session_assignment }
         else

--- a/app/controllers/session_assignments_controller.rb
+++ b/app/controllers/session_assignments_controller.rb
@@ -1,4 +1,6 @@
 class SessionAssignmentsController < ApplicationController
+  include ApplicantState
+
   devise_group :logged_in, contains: [:user, :admin]
   before_action :authenticate_logged_in!
   before_action :authenticate_admin!, only: [:index, :destroy]
@@ -14,7 +16,7 @@ class SessionAssignmentsController < ApplicationController
         status_array = SessionAssignment.where(enrollment_id: @current_enrollment).pluck(:offer_status)
         if status_array.count("accepted") + status_array.count("declined") == status_array.size
           enroll_id = @session_assignment.enrollment_id
-          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today)
+          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today, balance_due_cents: balance_due)
         end
         format.html { redirect_to all_payments_path, notice: 'Session assignment was successfully accepted.' }
         format.json { render :show, status: :ok, location: @session_assignment }
@@ -45,7 +47,7 @@ class SessionAssignmentsController < ApplicationController
           format.json { render :show, status: :ok, location: @session_assignment }
         elsif status_array.count("accepted") + status_array.count("declined") == status_array.size
           enroll_id = @session_assignment.enrollment_id
-          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today)
+          Enrollment.find(enroll_id).update(offer_status: "accepted", application_status: "offer accepted", application_status_updated_on: Date.today, balance_due_cents: balance_due)
           format.html { redirect_to all_payments_path, notice: 'Session assignment was declined.' }
           format.json { render :show, status: :ok, location: @session_assignment }
         else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,9 +36,9 @@ module ApplicationHelper
     @current_enrollment = current_user.enrollments.current_camp_year_applications.last
   end
   
-  def student_packet_url 
-    CampConfiguration.active.pick(:student_packet_url)
-  end
+  # def student_packet_url 
+  #   CampConfiguration.active.pick(:student_packet_url)
+  # end
 
   def current_camp_fee
     CampConfiguration.active_camp_fee_cents

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,9 +36,9 @@ module ApplicationHelper
     @current_enrollment = current_user.enrollments.current_camp_year_applications.last
   end
   
-  # def student_packet_url 
-  #   CampConfiguration.active.pick(:student_packet_url)
-  # end
+  def student_packet_url 
+    CampConfiguration.active.pick(:student_packet_url)
+  end
 
   def current_camp_fee
     CampConfiguration.active_camp_fee_cents

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -27,6 +27,7 @@
 #  application_deadline          :date
 #  application_status_updated_on :date
 #  camp_doc_form_completed       :boolean          default(FALSE)
+#  balance_due_cents             :integer
 #
 class Enrollment < ApplicationRecord
   after_update :send_offer_letter

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -26,6 +26,7 @@
 #  campyear                      :integer
 #  application_deadline          :date
 #  application_status_updated_on :date
+#  camp_doc_form_completed       :boolean          default(FALSE)
 #
 class Enrollment < ApplicationRecord
   after_update :send_offer_letter

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -101,6 +101,7 @@ class Enrollment < ApplicationRecord
   scope :no_student_packet, -> { current_camp_year_applications.where.not(id: Enrollment.current_camp_year_applications.joins(:student_packet_attachment).pluck(:id)) }
   scope :no_vaccine_record, -> { enrolled.where.not(id: Enrollment.current_camp_year_applications.joins(:vaccine_record_attachment).pluck(:id)) }
   scope :no_covid_test_record, -> { enrolled.where.not(id: Enrollment.current_camp_year_applications.joins(:covid_test_record_attachment).pluck(:id)) }
+  scope :no_camp_doc_form, -> { current_camp_year_applications.where(camp_doc_form_completed: false) }
 
   def display_name
     "#{self.applicant_detail.full_name} - #{self.user.email}"

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -30,9 +30,11 @@
 #  balance_due_cents             :integer
 #
 class Enrollment < ApplicationRecord
-  after_update :send_offer_letter
+  
+  before_update :if_camp_doc_form_completed
   before_update :if_application_status_changed
   before_update :set_application_deadline
+  after_update :send_offer_letter
   after_commit :send_enroll_letter, if: :persisted?
   after_commit :send_rejected_letter, if: :persisted?
   after_commit :send_waitlisted_letter, if: :persisted?
@@ -205,6 +207,12 @@ class Enrollment < ApplicationRecord
   def set_application_deadline
     if self.session_assignments.present? && self.course_assignments.present?
       self.application_deadline = 30.days.from_now unless self.application_deadline.present?
+    end
+  end
+
+  def if_camp_doc_form_completed
+    if self.camp_doc_form_completed && self.balance_due_cents == 0
+      self.application_status = "enrolled"
     end
   end
 

--- a/app/models/financial_aid.rb
+++ b/app/models/financial_aid.rb
@@ -50,7 +50,7 @@ class FinancialAid < ApplicationRecord
 
     if self.status == 'awarded'
       FinaidMailer.fin_aid_awarded_email(self, balance_due).deliver_now
-      if @current_enrollment.student_packet.attached? && balance_due == 0
+      if @current_enrollment.camp_doc_form_completed && balance_due == 0
         @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today)
       end
     end

--- a/app/models/financial_aid.rb
+++ b/app/models/financial_aid.rb
@@ -51,7 +51,9 @@ class FinancialAid < ApplicationRecord
     if self.status == 'awarded'
       FinaidMailer.fin_aid_awarded_email(self, balance_due).deliver_now
       if @current_enrollment.camp_doc_form_completed && balance_due == 0
-        @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today)
+        @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today, balance_due_cents: balance_due)
+      else
+        @current_enrollment.update!(balance_due_cents: balance_due)
       end
     end
     if self.status == 'rejected'

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -42,7 +42,7 @@ class Payment < ApplicationRecord
     @current_enrollment = self.user.enrollments.current_camp_year_applications.last
     if self.user.payments.current_camp_payments.where(transaction_status: 1).count == 1
       RegistrationMailer.app_complete_email(self.user).deliver_now
-      @current_enrollment.update!(application_status: "submitted", application_status_updated_on: Date.today)
+      @current_enrollment.update!(application_status: "submitted", application_status_updated_on: Date.today, balance_due_cents: balance_due)
       if @current_enrollment.recommendation.present?
         if @current_enrollment.recommendation.recupload.present? 
           @current_enrollment.update!(application_status: "application complete", application_status_updated_on: Date.today)
@@ -50,7 +50,9 @@ class Payment < ApplicationRecord
       end
     else 
       if balance_due == 0 && @current_enrollment.camp_doc_form_completed
-        @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today)
+        @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today, balance_due_cents: balance_due)
+      else
+        @current_enrollment.update!(balance_due_cents: balance_due)
       end
     end
   end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -49,7 +49,7 @@ class Payment < ApplicationRecord
         end
       end
     else 
-      if balance_due == 0 && @current_enrollment.student_packet.attached?
+      if balance_due == 0 && @current_enrollment.camp_doc_form_completed
         @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today)
       end
     end

--- a/app/views/admin/_testing_partial_display.erb
+++ b/app/views/admin/_testing_partial_display.erb
@@ -4,8 +4,8 @@
         link_to enroll.transcript.filename, url_for(enroll.transcript)
       end
     end
-    column "Student Packet" do |sp|
-      if sp.student_packet.attached?
-        link_to sp.student_packet.filename, url_for(sp.student_packet)
-      end
+    # column "Student Packet" do |sp|
+    #   if sp.student_packet.attached?
+    #     link_to sp.student_packet.filename, url_for(sp.student_packet)
+    #   end
     end

--- a/app/views/layouts/_sidebox.html.erb
+++ b/app/views/layouts/_sidebox.html.erb
@@ -127,38 +127,40 @@
               <% end %>
             </div>
             <hr>
-            <h4>Download and return the <br>
-              <div class="my-2">
-                <%= link_to student_packet_url, class: "btn btn-blue", target: "_blank" do %>
-                  Student Information Packet
+            <div class="hidden">
+              <h4>Download and return the <br>
+                <div class="my-2">
+                  <%= link_to student_packet_url, class: "btn btn-blue", target: "_blank" do %>
+                    Student Information Packet
+                  <% end %>
+                </div>
+              </h4>
+              <%= form_with(model: current_enrollment, local: true) do |form| %>
+                <p class="text-xs">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
+                <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
+                if your file size is larger than 20MBytes.</p>
+                <% if current_enrollment.student_packet.attached? %>
+                  <div class='current-uploaded-docs'>
+                    <p>
+                      <strong>Student Packet currently uploaded:</strong>
+                      <%= link_to current_enrollment.student_packet.filename, url_for(current_enrollment.student_packet) %>
+                    </p>
+                  </div>
+                  <div class="field">
+                    <%= form.label :student_packet, 'Update Student Packet' %>
+                    <%= form.file_field :student_packet %>
+                  </div>
+                <% else %>
+                  <div class="field">
+                    <%= form.label :student_packet, 'Upload Student Packet' %>
+                    <%= form.file_field :student_packet, required: true %>
+                  </div>
                 <% end %>
-              </div>
-            </h4>
-            <%= form_with(model: current_enrollment, local: true) do |form| %>
-              <p class="text-xs">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
-              <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
-              if your file size is larger than 20MBytes.</p>
-              <% if current_enrollment.student_packet.attached? %>
-                <div class='current-uploaded-docs'>
-                  <p>
-                    <strong>Student Packet currently uploaded:</strong>
-                    <%= link_to current_enrollment.student_packet.filename, url_for(current_enrollment.student_packet) %>
-                  </p>
-                </div>
-                <div class="field">
-                  <%= form.label :student_packet, 'Update Student Packet' %>
-                  <%= form.file_field :student_packet %>
-                </div>
-              <% else %>
-                <div class="field">
-                  <%= form.label :student_packet, 'Upload Student Packet' %>
-                  <%= form.file_field :student_packet, required: true %>
+                <div class="actions">
+                  <%= form.submit "Upload Student Packet", id: 'student_packet_submit' %>
                 </div>
               <% end %>
-              <div class="actions">
-                <%= form.submit "Upload Student Packet", id: 'student_packet_submit' %>
-              </div>
-            <% end %>
+            </div>
             <div class="hidden covid-panel">
               <hr>
               <hr>

--- a/app/views/static_pages/_directions.html.erb
+++ b/app/views/static_pages/_directions.html.erb
@@ -99,13 +99,15 @@
       </div>
     <% elsif @current_enrollment.application_status == "offer accepted" %>
       <div class="m-2">
-        <% unless current_enrollment.student_packet.attached? %>
-          <p>You need to download, fill out and upload the Student Information Packet using
-          the button in the progress window to the right.</p>
-          <p class="direction_notes">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
-            <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
-            if your file size is larger than 20MBytes.</p> 
-        <% end %>
+        <div class="hidden">
+          <% unless current_enrollment.student_packet.attached? %>
+            <p>You need to download, fill out and upload the Student Information Packet using
+            the button in the progress window to the right.</p>
+            <p class="direction_notes">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
+              <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
+              if your file size is larger than 20MBytes.</p> 
+          <% end %>
+        </div>
         <p>Please refer to your offer email for the payment deadline. To 
         check your account balance click the button below.</p>
         <div class="my-2">

--- a/db/migrate/20241021230137_add_camp_doc_form_completed_to_enrollment.rb
+++ b/db/migrate/20241021230137_add_camp_doc_form_completed_to_enrollment.rb
@@ -1,0 +1,5 @@
+class AddCampDocFormCompletedToEnrollment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :enrollments, :camp_doc_form_completed, :boolean, default: false
+  end
+end

--- a/db/migrate/20241024193249_add_balance_due_to_enrollment.rb
+++ b/db/migrate/20241024193249_add_balance_due_to_enrollment.rb
@@ -1,0 +1,5 @@
+class AddBalanceDueToEnrollment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :enrollments, :balance_due_cents, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_21_230137) do
+ActiveRecord::Schema.define(version: 2024_10_24_193249) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "namespace"
@@ -227,6 +227,7 @@ ActiveRecord::Schema.define(version: 2024_10_21_230137) do
     t.date "application_status_updated_on"
     t.string "uniqname"
     t.boolean "camp_doc_form_completed", default: false
+    t.integer "balance_due_cents"
     t.index ["user_id"], name: "index_enrollments_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_18_135603) do
+ActiveRecord::Schema.define(version: 2024_10_21_230137) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "namespace"
@@ -226,6 +226,7 @@ ActiveRecord::Schema.define(version: 2023_01_18_135603) do
     t.date "application_deadline"
     t.date "application_status_updated_on"
     t.string "uniqname"
+    t.boolean "camp_doc_form_completed", default: false
     t.index ["user_id"], name: "index_enrollments_on_user_id"
   end
 


### PR DESCRIPTION
I commented the student_packet mentions in the Active Admin camp configuration and enrollment forms and views. I didn't delete the code because vaccine_record and covid_test_record were also commented, and not deleted.

I hid the 'download and display' student_packet code in the User Interface's sidebox (the same way vaccine_record and covid_test_record were hidden).

To the enrollment model, I added two fields: camp_doc_form_completed and balance_due_cents.

camp_doc_form_completed field (checkbox) was added to the Active Adnin enrollment page - the fields should be updated by admins manually.

I replaced checks @current_enrollment.student_packet.attached? with @current_enrollment.camp_doc_form_completed.

Since the application_status should be updated to 'enrolled' if `@current_enrollment.camp_doc_form_completed && balance_due == 0`, and that should be done in the enrollment model I used the newly added field balance_due_cents to run the `before_update :if_camp_doc_form_completed` validation.

Other places where the application_status is updated to "enrolled" are the FinancialAid and Payment models and EnrollmentsController (on update) in case money (or other updates) are added to an enrollment.

For that to happen the balance_due_cents value should be updated each time a payment is made or the offer is accepted by a user (this one is needed in case the admin updates camp_doc_form_completed to true but the student has not paid for the session course and activities - the application_status should not be changed to 'enrolled' yet).

'No Camp Doc Form' scope was added to Active Admin.
