### PR TITLE
Lra 1021 mmss change student packet upload process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,6 +479,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/app/admin/camp_configurations.rb
+++ b/app/admin/camp_configurations.rb
@@ -48,7 +48,7 @@ ActiveAdmin.register CampConfiguration do
      f.input :camper_acceptance_due
      f.input :active
      f.input :offer_letter
-     f.input :student_packet_url
+    #  f.input :student_packet_url
      f.input :application_fee
      f.input :reject_letter
      f.input :waitlist_letter
@@ -66,7 +66,7 @@ ActiveAdmin.register CampConfiguration do
     column :application_materials_due
     column :camper_acceptance_due
     column :active
-    column :student_packet_url
+    # column :student_packet_url
     column "Application Fee" do |af|
       humanized_money_with_symbol(af.application_fee)
     end
@@ -90,7 +90,7 @@ ActiveAdmin.register CampConfiguration do
     row "Wait list Letter Text" do |item|
       item.waitlist_letter
     end
-    row :student_packet_url
+    # row :student_packet_url
     row "Application fee" do |cc|
       humanized_money_with_symbol(cc.application_fee)
     end

--- a/app/admin/camp_configurations.rb
+++ b/app/admin/camp_configurations.rb
@@ -11,14 +11,6 @@ ActiveAdmin.register CampConfiguration do
                   :camper_acceptance_due, :active, :offer_letter, 
                   :student_packet_url, :application_fee,
                   :reject_letter, :waitlist_letter
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:camp_year, :application_open, :application_close, :priority, :application_materials_due, :camper_acceptance_due, :active]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
 
   controller do
     # Custom new method
@@ -48,7 +40,6 @@ ActiveAdmin.register CampConfiguration do
      f.input :camper_acceptance_due
      f.input :active
      f.input :offer_letter
-    #  f.input :student_packet_url
      f.input :application_fee
      f.input :reject_letter
      f.input :waitlist_letter
@@ -66,7 +57,6 @@ ActiveAdmin.register CampConfiguration do
     column :application_materials_due
     column :camper_acceptance_due
     column :active
-    # column :student_packet_url
     column "Application Fee" do |af|
       humanized_money_with_symbol(af.application_fee)
     end
@@ -90,7 +80,6 @@ ActiveAdmin.register CampConfiguration do
     row "Wait list Letter Text" do |item|
       item.waitlist_letter
     end
-    # row :student_packet_url
     row "Application fee" do |cc|
       humanized_money_with_symbol(cc.application_fee)
     end

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
                   :high_school_state, :high_school_non_us, 
                   :high_school_postalcode, :high_school_country, 
                   :year_in_school, :anticipated_graduation_year, 
-                  :room_mate_request, :personal_statement, 
+                  :room_mate_request, :personal_statement, :camp_doc_form_completed,
                   :shirt_size, :notes, :application_status, :application_status_updated_on, :campyear,
                   :offer_status, :partner_program, :transcript, :student_packet, 
                   :application_deadline, :vaccine_record, :covid_test_record, :uniqname,
@@ -93,6 +93,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
 
       end
      f.input :transcript, as: :file, label: "Update transcript"
+     f.input :camp_doc_form_completed
     #  f.input :student_packet, as: :file, label: "Update student_packet"
     #  f.input :vaccine_record, as: :file, label: "Update vaccine_record"
     #  f.input :covid_test_record, as: :file, label: "Update covid_test_record"
@@ -170,6 +171,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
     #     link_to sp.covid_test_record.filename, url_for(sp.covid_test_record)
     #   end
     # end
+    column :camp_doc_form_completed
     column :offer_status
     column :application_deadline
     column :application_status
@@ -337,6 +339,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
           link_to tr.transcript.filename, url_for(tr.transcript)
         end
       end
+      row :camp_doc_form_completed
       # row :student_packet do |sp|
       #   if sp.student_packet.attached?
       #     link_to sp.student_packet.filename, url_for(sp.student_packet)
@@ -396,6 +399,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
     column :room_mate_request
     column :notes
     column :partner_program
+    column :camp_doc_form_completed
     column "Balance Due" do |app|
       humanized_money_with_symbol(PaymentState.new(app).balance_due / 100)
     end

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -32,7 +32,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
   scope :no_recomendation, group: :missing
   scope :no_letter, group: :missing
   scope :no_payments, group: :missing
-  scope :no_student_packet, group: :missing
+  # scope :no_student_packet, group: :missing
 
   # scope :no_vaccine_record, group: :vaccine
   # scope :no_covid_test_record, group: :vaccine
@@ -75,11 +75,11 @@ ActiveAdmin.register Enrollment, as: "Application" do
             link_to item.transcript.filename, url_for(item.transcript)
           end
         end
-        column "Current Student Packet" do |item| 
-          if item.student_packet.attached?
-            link_to item.student_packet.filename, url_for(item.student_packet)
-          end
-        end
+        # column "Current Student Packet" do |item| 
+        #   if item.student_packet.attached?
+        #     link_to item.student_packet.filename, url_for(item.student_packet)
+        #   end
+        # end
         # column "Vaccine Record" do |item| 
         #   if item.vaccine_record.attached?
         #     link_to item.vaccine_record.filename, url_for(item.vaccine_record)
@@ -93,7 +93,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
 
       end
      f.input :transcript, as: :file, label: "Update transcript"
-     f.input :student_packet, as: :file, label: "Update student_packet"
+    #  f.input :student_packet, as: :file, label: "Update student_packet"
     #  f.input :vaccine_record, as: :file, label: "Update vaccine_record"
     #  f.input :covid_test_record, as: :file, label: "Update covid_test_record"
       hr
@@ -155,11 +155,11 @@ ActiveAdmin.register Enrollment, as: "Application" do
         link_to enroll.transcript.filename, url_for(enroll.transcript)
       end
     end
-    column "Student Packet" do |sp|
-      if sp.student_packet.attached?
-        link_to sp.student_packet.filename, url_for(sp.student_packet)
-      end
-    end
+    # column "Student Packet" do |sp|
+    #   if sp.student_packet.attached?
+    #     link_to sp.student_packet.filename, url_for(sp.student_packet)
+    #   end
+    # end
     # column "Vaccination Record" do |enroll|
     #   if enroll.vaccine_record.attached?
     #     link_to enroll.vaccine_record.filename, url_for(enroll.vaccine_record)
@@ -337,11 +337,11 @@ ActiveAdmin.register Enrollment, as: "Application" do
           link_to tr.transcript.filename, url_for(tr.transcript)
         end
       end
-      row :student_packet do |sp|
-        if sp.student_packet.attached?
-          link_to sp.student_packet.filename, url_for(sp.student_packet)
-        end
-      end
+      # row :student_packet do |sp|
+      #   if sp.student_packet.attached?
+      #     link_to sp.student_packet.filename, url_for(sp.student_packet)
+      #   end
+      # end
       # row :vaccine_record do |tr|
       #   if tr.vaccine_record.attached?
       #     link_to tr.vaccine_record.filename, url_for(tr.vaccine_record)
@@ -381,11 +381,11 @@ ActiveAdmin.register Enrollment, as: "Application" do
         "uploaded"
       end
     end
-    column "Student Packet" do |sp|
-      if sp.student_packet.attached?
-        "uploaded"
-      end
-    end
+    # column "Student Packet" do |sp|
+    #   if sp.student_packet.attached?
+    #     "uploaded"
+    #   end
+    # end
     column :offer_status
     column :application_deadline
     column :application_status

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -33,10 +33,6 @@ ActiveAdmin.register Enrollment, as: "Application" do
   scope :no_letter, group: :missing
   scope :no_payments, group: :missing
   scope :no_camp_doc_form, group: :missing
-  # scope :no_student_packet, group: :missing
-
-  # scope :no_vaccine_record, group: :vaccine
-  # scope :no_covid_test_record, group: :vaccine
 
   action_item :set_waitlisted, only: :show do
     text_node link_to("Place on Wait List", waitlisted_path(application), data: { confirm: 'Are you sure you want to wait list this application?'}, method: :post ) if ["application complete"].include? application.application_status
@@ -76,28 +72,9 @@ ActiveAdmin.register Enrollment, as: "Application" do
             link_to item.transcript.filename, url_for(item.transcript)
           end
         end
-        # column "Current Student Packet" do |item| 
-        #   if item.student_packet.attached?
-        #     link_to item.student_packet.filename, url_for(item.student_packet)
-        #   end
-        # end
-        # column "Vaccine Record" do |item| 
-        #   if item.vaccine_record.attached?
-        #     link_to item.vaccine_record.filename, url_for(item.vaccine_record)
-        #   end
-        # end
-        # column "COVID Test" do |item| 
-        #   if item.covid_test_record.attached?
-        #     link_to item.covid_test_record.filename, url_for(item.covid_test_record)
-        #   end
-        # end
-
       end
      f.input :transcript, as: :file, label: "Update transcript"
      f.input :camp_doc_form_completed
-    #  f.input :student_packet, as: :file, label: "Update student_packet"
-    #  f.input :vaccine_record, as: :file, label: "Update vaccine_record"
-    #  f.input :covid_test_record, as: :file, label: "Update covid_test_record"
       hr
      f.input :notes
      f.input :partner_program
@@ -157,21 +134,6 @@ ActiveAdmin.register Enrollment, as: "Application" do
         link_to enroll.transcript.filename, url_for(enroll.transcript)
       end
     end
-    # column "Student Packet" do |sp|
-    #   if sp.student_packet.attached?
-    #     link_to sp.student_packet.filename, url_for(sp.student_packet)
-    #   end
-    # end
-    # column "Vaccination Record" do |enroll|
-    #   if enroll.vaccine_record.attached?
-    #     link_to enroll.vaccine_record.filename, url_for(enroll.vaccine_record)
-    #   end
-    # end
-    # column "COVID Test" do |sp|
-    #   if sp.covid_test_record.attached?
-    #     link_to sp.covid_test_record.filename, url_for(sp.covid_test_record)
-    #   end
-    # end
     column :camp_doc_form_completed
     column :offer_status
     column :application_deadline
@@ -341,21 +303,6 @@ ActiveAdmin.register Enrollment, as: "Application" do
         end
       end
       row :camp_doc_form_completed
-      # row :student_packet do |sp|
-      #   if sp.student_packet.attached?
-      #     link_to sp.student_packet.filename, url_for(sp.student_packet)
-      #   end
-      # end
-      # row :vaccine_record do |tr|
-      #   if tr.vaccine_record.attached?
-      #     link_to tr.vaccine_record.filename, url_for(tr.vaccine_record)
-      #   end
-      # end
-      # row :covid_test_record do |sp|
-      #   if sp.covid_test_record.attached?
-      #     link_to sp.covid_test_record.filename, url_for(sp.covid_test_record)
-      #   end
-      # end
       row :international
       row :high_school_name
       row :high_school_address1
@@ -385,11 +332,6 @@ ActiveAdmin.register Enrollment, as: "Application" do
         "uploaded"
       end
     end
-    # column "Student Packet" do |sp|
-    #   if sp.student_packet.attached?
-    #     "uploaded"
-    #   end
-    # end
     column :offer_status
     column :application_deadline
     column :application_status

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -32,6 +32,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
   scope :no_recomendation, group: :missing
   scope :no_letter, group: :missing
   scope :no_payments, group: :missing
+  scope :no_camp_doc_form, group: :missing
   # scope :no_student_packet, group: :missing
 
   # scope :no_vaccine_record, group: :vaccine

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -58,7 +58,7 @@ class EnrollmentsController < ApplicationController
   def update
     respond_to do |format|
       if @current_enrollment.update(enrollment_params)
-        if @current_enrollment.student_packet.attached? && balance_due == 0
+        if @current_enrollment.camp_doc_form_completed && balance_due == 0
           @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today)
         end
         format.html { redirect_to root_path, notice: 'Application was successfully updated.' }
@@ -164,7 +164,7 @@ class EnrollmentsController < ApplicationController
                           :personal_statement, :shirt_size, :notes,
                           :application_status, :offer_status,
                           :partner_program, :transcript,
-                          :student_packet, :campyear,
+                          :student_packet, :campyear, :camp_doc_form_completed,
                           :vaccine_record, :covid_test_record,
                           registration_activity_ids: [],
                           session_registration_ids: [],

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -27,6 +27,7 @@
 #  application_deadline          :date
 #  application_status_updated_on :date
 #  uniqname                      :string(255)
+#  camp_doc_form_completed       :boolean          default(FALSE)
 #
 class Enrollment < ApplicationRecord
   after_update :send_offer_letter

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -100,6 +100,7 @@ class Enrollment < ApplicationRecord
   scope :no_student_packet, -> { current_camp_year_applications.where.not(id: Enrollment.current_camp_year_applications.joins(:student_packet_attachment).pluck(:id)) }
   scope :no_vaccine_record, -> { enrolled.where.not(id: Enrollment.current_camp_year_applications.joins(:vaccine_record_attachment).pluck(:id)) }
   scope :no_covid_test_record, -> { enrolled.where.not(id: Enrollment.current_camp_year_applications.joins(:covid_test_record_attachment).pluck(:id)) }
+  scope :no_camp_doc_form, -> { current_camp_year_applications.where(camp_doc_form_completed: false) }
 
   def display_name
     "#{self.applicant_detail.full_name} - #{self.user.email}"

--- a/app/models/financial_aid.rb
+++ b/app/models/financial_aid.rb
@@ -50,7 +50,7 @@ class FinancialAid < ApplicationRecord
 
     if self.status == 'awarded'
       FinaidMailer.fin_aid_awarded_email(self, balance_due).deliver_now
-      if @current_enrollment.student_packet.attached? && balance_due == 0
+      if @current_enrollment.camp_doc_form_completed && balance_due == 0
         @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today)
       end
     end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -49,7 +49,7 @@ class Payment < ApplicationRecord
         end
       end
     else 
-      if balance_due == 0 && @current_enrollment.student_packet.attached?
+      if balance_due == 0 && @current_enrollment.camp_doc_form_completed
         @current_enrollment.update!(application_status: "enrolled", application_status_updated_on: Date.today)
       end
     end

--- a/app/views/layouts/_sidebox.html.erb
+++ b/app/views/layouts/_sidebox.html.erb
@@ -130,7 +130,7 @@
             <span><strong>Health Forms</strong></span>
             <% if current_enrollment.camp_doc_form_completed %>
               <p>
-                The forms has been filled out
+                Completed
               </p>
             <% else %>
               <p>
@@ -139,127 +139,6 @@
                 Enrollment will not be finalized until the health forms are completed.          
               </p>
             <% end %>
-            <div class="hidden">
-              <span>Download and return the <span>
-                <div class="my-2">
-                  <%= link_to student_packet_url, class: "btn btn-blue", target: "_blank" do %>
-                    Student Information Packet
-                  <% end %>
-                </div>
-              <%= form_with(model: current_enrollment, local: true) do |form| %>
-                <p class="text-xs">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
-                <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
-                if your file size is larger than 20MBytes.</p>
-                <% if current_enrollment.student_packet.attached? %>
-                  <div class='current-uploaded-docs'>
-                    <p>
-                      <strong>Student Packet currently uploaded:</strong>
-                      <%= link_to current_enrollment.student_packet.filename, url_for(current_enrollment.student_packet) %>
-                    </p>
-                  </div>
-                  <div class="field">
-                    <%= form.label :student_packet, 'Update Student Packet' %>
-                    <%= form.file_field :student_packet, 
-                            data: { 
-                              controller: "filesize-check", 
-                              action: "filesize-check#validateFileSize", 
-                              filesize_check_max_file_size_value: 20 * 1024 * 1024 
-                            } %>
-                  </div>
-                <% else %>
-                  <div class="field">
-                    <%= form.label :student_packet, 'Upload Student Packet' %>
-                    <%= form.file_field :student_packet, 
-                            data: { 
-                              controller: "filesize-check", 
-                              action: "filesize-check#validateFileSize", 
-                              filesize_check_max_file_size_value: 20 * 1024 * 1024 
-                            } %>
-                  </div>
-                <% end %>
-                <div class="actions">
-                  <%= form.submit "Upload Student Packet", id: 'student_packet_submit' %>
-                </div>
-              <% end %>
-            </div>
-            <div class="hidden covid-panel">
-              <hr>
-              <hr>
-              <h2 class="text-red-700"> !! COVID Information !! </h2>
-              <span>* Upload a copy of your Vaccine Record</span>
-              <%= form_with(model: current_enrollment, local: true) do |form| %>
-                <p class="text-xs">File uploads are limited to files smaller than 20Mbytes. You can use an 
-                <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
-                if your file size is larger than 20MBytes.</p>
-                <% if current_enrollment.vaccine_record.attached? %>
-                  <div class='current-uploaded-docs'>
-                    <p>
-                      <strong>Vaccine Record currently uploaded:</strong>
-                      <%= link_to current_enrollment.vaccine_record.filename, url_for(current_enrollment.vaccine_record) %>
-                    </p>
-                  </div>
-                  <div class="field">
-                    <%= form.label :vaccine_record, 'Update Vaccine Record' %>
-                    <%= form.file_field :vaccine_record, 
-                            data: { 
-                              controller: "filesize-check", 
-                              action: "filesize-check#validateFileSize", 
-                              filesize_check_max_file_size_value: 20 * 1024 * 1024 
-                            } %>
-                  </div>
-                <% else %>
-                  <div class="field">
-                    <%= form.label :vaccine_record, 'Upload Vaccine Record' %>
-                    <%= form.file_field :vaccine_record, 
-                            data: { 
-                              controller: "filesize-check", 
-                              action: "filesize-check#validateFileSize", 
-                              filesize_check_max_file_size_value: 20 * 1024 * 1024 
-                            } %>
-                  </div>
-                <% end %>
-                <div class="actions">
-                  <%= form.submit "Upload Vaccine Record", id: 'vaccine_record_submit' %>
-                </div>
-              <% end %>
-
-              <div class="hidden covid-test-panel" >
-                <hr>
-                <span>* Upload a copy of your Covid Test Report</span>
-                <%= form_with(model: current_enrollment, local: true) do |form| %>
-                  <% if current_enrollment.covid_test_record.attached? %>
-                    <div class='current-uploaded-docs'>
-                      <p>
-                        <strong>Covid Test Report currently uploaded:</strong>
-                        <%= link_to current_enrollment.covid_test_record.filename, url_for(current_enrollment.covid_test_record) %>
-                      </p>
-                    </div>
-                    <div class="field">
-                      <%= form.label :covid_test_record, 'Update Covid Test Report' %>
-                      <%= form.file_field :covid_test_record, 
-                              data: { 
-                                controller: "filesize-check", 
-                                action: "filesize-check#validateFileSize", 
-                                filesize_check_max_file_size_value: 20 * 1024 * 1024 
-                              } %>
-                    </div>
-                  <% else %>
-                    <div class="field">
-                      <%= form.label :covid_test_record, 'Upload Covid Test Report' %>
-                      <%= form.file_field :covid_test_record, 
-                              data: { 
-                                controller: "filesize-check", 
-                                action: "filesize-check#validateFileSize", 
-                                filesize_check_max_file_size_value: 20 * 1024 * 1024 
-                              } %>
-                    </div>
-                  <% end %>
-                  <div class="actions">
-                    <%= form.submit "Upload Covid Test Report", id: 'covid_test_record_submit' %>
-                  </div>
-                <% end %>
-              </div>
-            </div>
           </div>
         <% elsif @current_enrollment.offer_status == "declined" %>
           <hr>

--- a/app/views/layouts/_sidebox.html.erb
+++ b/app/views/layouts/_sidebox.html.erb
@@ -100,7 +100,7 @@
         <% elsif current_enrollment.offer_status == "accepted" %>
           <hr>
           <div>
-            <span class="text-green-700 font-semibold">You have accepted admission</span>
+            <span class="text-green-umgreen font-semibold">You have accepted admission</span>
             <% current_enrollment.session_assignments.each do |sa| %>
               <% if sa.offer_status == "accepted" %>
               <div>
@@ -127,24 +127,25 @@
               <% end %>
             </div>
             <hr>
-            <h4>Camp Doc form<br>
+            <span><strong>Health Forms</strong></span>
             <% if current_enrollment.camp_doc_form_completed %>
               <p>
-                <strong>The form has been filled out</strong>
+                The forms has been filled out
               </p>
             <% else %>
               <p>
-                Please fill the forem on Camp Doc             
+                The parent email address on file will be sent an invitation to complete health forms on Camp Doc 
+                after the balance has been paid in full. Please complete the forms as soon as possible. 
+                Enrollment will not be finalized until the health forms are completed.          
               </p>
             <% end %>
             <div class="hidden">
-              <h4>Download and return the <br>
+              <span>Download and return the <span>
                 <div class="my-2">
                   <%= link_to student_packet_url, class: "btn btn-blue", target: "_blank" do %>
                     Student Information Packet
                   <% end %>
                 </div>
-              </h4>
               <%= form_with(model: current_enrollment, local: true) do |form| %>
                 <p class="text-xs">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
                 <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
@@ -185,7 +186,7 @@
               <hr>
               <hr>
               <h2 class="text-red-700"> !! COVID Information !! </h2>
-              <h4>* Upload a copy of your Vaccine Record</h4>
+              <span>* Upload a copy of your Vaccine Record</span>
               <%= form_with(model: current_enrollment, local: true) do |form| %>
                 <p class="text-xs">File uploads are limited to files smaller than 20Mbytes. You can use an 
                 <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
@@ -224,7 +225,7 @@
 
               <div class="hidden covid-test-panel" >
                 <hr>
-                <h4>* Upload a copy of your Covid Test Report</h4>
+                <span>* Upload a copy of your Covid Test Report</span>
                 <%= form_with(model: current_enrollment, local: true) do |form| %>
                   <% if current_enrollment.covid_test_record.attached? %>
                     <div class='current-uploaded-docs'>
@@ -263,7 +264,7 @@
         <% elsif @current_enrollment.offer_status == "declined" %>
           <hr>
           <div>
-            <span class="text-red-700 font-semibold">You have declined admission</span>
+            <span class="text-red-umred font-semibold">You have declined admission</span>
           </div>
         <% else %>
           <hr>

--- a/app/views/layouts/_sidebox.html.erb
+++ b/app/views/layouts/_sidebox.html.erb
@@ -127,48 +127,60 @@
               <% end %>
             </div>
             <hr>
-            <h4>Download and return the <br>
-              <div class="my-2">
-                <%= link_to student_packet_url, class: "btn btn-blue", target: "_blank" do %>
-                  Student Information Packet
+            <h4>Camp Doc form<br>
+            <% if current_enrollment.camp_doc_form_completed %>
+              <p>
+                <strong>The form has been filled out</strong>
+              </p>
+            <% else %>
+              <p>
+                Please fill the forem on Camp Doc             
+              </p>
+            <% end %>
+            <div class="hidden">
+              <h4>Download and return the <br>
+                <div class="my-2">
+                  <%= link_to student_packet_url, class: "btn btn-blue", target: "_blank" do %>
+                    Student Information Packet
+                  <% end %>
+                </div>
+              </h4>
+              <%= form_with(model: current_enrollment, local: true) do |form| %>
+                <p class="text-xs">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
+                <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
+                if your file size is larger than 20MBytes.</p>
+                <% if current_enrollment.student_packet.attached? %>
+                  <div class='current-uploaded-docs'>
+                    <p>
+                      <strong>Student Packet currently uploaded:</strong>
+                      <%= link_to current_enrollment.student_packet.filename, url_for(current_enrollment.student_packet) %>
+                    </p>
+                  </div>
+                  <div class="field">
+                    <%= form.label :student_packet, 'Update Student Packet' %>
+                    <%= form.file_field :student_packet, 
+                            data: { 
+                              controller: "filesize-check", 
+                              action: "filesize-check#validateFileSize", 
+                              filesize_check_max_file_size_value: 20 * 1024 * 1024 
+                            } %>
+                  </div>
+                <% else %>
+                  <div class="field">
+                    <%= form.label :student_packet, 'Upload Student Packet' %>
+                    <%= form.file_field :student_packet, 
+                            data: { 
+                              controller: "filesize-check", 
+                              action: "filesize-check#validateFileSize", 
+                              filesize_check_max_file_size_value: 20 * 1024 * 1024 
+                            } %>
+                  </div>
                 <% end %>
-              </div>
-            </h4>
-            <%= form_with(model: current_enrollment, local: true) do |form| %>
-              <p class="text-xs">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
-              <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
-              if your file size is larger than 20MBytes.</p>
-              <% if current_enrollment.student_packet.attached? %>
-                <div class='current-uploaded-docs'>
-                  <p>
-                    <strong>Student Packet currently uploaded:</strong>
-                    <%= link_to current_enrollment.student_packet.filename, url_for(current_enrollment.student_packet) %>
-                  </p>
-                </div>
-                <div class="field">
-                  <%= form.label :student_packet, 'Update Student Packet' %>
-                  <%= form.file_field :student_packet, 
-                          data: { 
-                            controller: "filesize-check", 
-                            action: "filesize-check#validateFileSize", 
-                            filesize_check_max_file_size_value: 20 * 1024 * 1024 
-                          } %>
-                </div>
-              <% else %>
-                <div class="field">
-                  <%= form.label :student_packet, 'Upload Student Packet' %>
-                  <%= form.file_field :student_packet, 
-                          data: { 
-                            controller: "filesize-check", 
-                            action: "filesize-check#validateFileSize", 
-                            filesize_check_max_file_size_value: 20 * 1024 * 1024 
-                          } %>
+                <div class="actions">
+                  <%= form.submit "Upload Student Packet", id: 'student_packet_submit' %>
                 </div>
               <% end %>
-              <div class="actions">
-                <%= form.submit "Upload Student Packet", id: 'student_packet_submit' %>
-              </div>
-            <% end %>
+            </div>
             <div class="hidden covid-panel">
               <hr>
               <hr>

--- a/app/views/payments/payment_show.html.erb
+++ b/app/views/payments/payment_show.html.erb
@@ -18,50 +18,50 @@
                       make_payment_path(amount: current_camp_fee / 100), class: 'btn btn-green' %>
       </p>
     <% else %>
-        <% if @current_application_status == "offer accepted" %>
-          <p class=my-2>
-            Your application materials have been received and processed, and we are
-            pleased to offer you a spot for MMSS <%= current_camp_year %>.
-            Your official notification and course assignment are found in your
-            notification email.
-            <br>
-            Paying the tuition and service fees is a requirement of participation.
-            Please continue paying your camp fees at this time.
-          </p>
-          <hr class="w-75" />
-        <% elsif  @current_application_status == "offer declined" %>
-          <p class="my-2"> Thanks for your interest.</p>
-        <% elsif  @current_application_status == "enrolled" %>
-          <p> Thank you for paying all your fees. We look forward to seeing you at MMSS <%= current_camp_year %>.</p>
-        <% else %>
-          <p class="my-2">
-            Thank you for your Michigan Math and Science Scholars Application. When we
-            have received all your application components your file will be reviewed.
-            <br>
-            The process may take up to 6 weeks as we conduct our admissions on a
-            rolling basis.
-            <br>
-            Please continue to check your email, and the Progress Window, for
-            updates on your application.
-          </p>
-        <% end %>
+      <% if @current_application_status == "offer accepted" %>
+        <p class=my-2>
+          Your application materials have been received and processed, and we are
+          pleased to offer you a spot for MMSS <%= current_camp_year %>.
+          Your official notification and course assignment are found in your
+          notification email.
+          <br>
+          Paying the tuition and service fees is a requirement of participation.
+          Please continue paying your camp fees at this time.
+        </p>
+        <hr class="w-75" />
+      <% elsif  @current_application_status == "offer declined" %>
+        <p class="my-2"> Thanks for your interest.</p>
+      <% elsif  @current_application_status == "enrolled" %>
+        <p> Thank you for paying all your fees. We look forward to seeing you at MMSS <%= current_camp_year %>.</p>
+      <% else %>
+        <p class="my-2">
+          Thank you for your Michigan Math and Science Scholars Application. When we
+          have received all your application components your file will be reviewed.
+          <br>
+          The process may take up to 6 weeks as we conduct our admissions on a
+          rolling basis.
+          <br>
+          Please continue to check your email, and the Progress Window, for
+          updates on your application.
+        </p>
+      <% end %>
 
-        <% if @current_enrollment.financial_aids.blank? && (@current_application_status == nil || @current_application_status == "" || @current_application_status == "submitted" || @current_application_status == "application complete") %>
-          <p class="mb-2">If you are applying for need-based financial support, please fill out the
-            <br>
-            <div class="my-2">
-              <%= link_to "Financial Aid Application", new_enrollment_financial_aid_path(@current_enrollment),
-                      class: "btn btn-green pt-8" %>
-            </div>
-          </p>
+      <% if @current_enrollment.financial_aids.blank? && (@current_application_status == nil || @current_application_status == "" || @current_application_status == "submitted" || @current_application_status == "application complete") %>
+        <p class="mb-2">If you are applying for need-based financial support, please fill out the
+          <br>
+          <div class="my-2">
+            <%= link_to "Financial Aid Application", new_enrollment_financial_aid_path(@current_enrollment),
+                    class: "btn btn-green pt-8" %>
+          </div>
+        </p>
+      <% end %>
+      <div class="direction_notes">You may email any questions to 
+        <%= mail_to "mmss@umich.edu", subject: "Question about MMSS"  do %>
+          <strong>mmss@umich.edu</strong>
         <% end %>
-        <div class="direction_notes">You may email any questions to 
-          <%= mail_to "mmss@umich.edu", subject: "Question about MMSS"  do %>
-            <strong>mmss@umich.edu</strong>
-          <% end %>
-        </div>
+      </div>
 
-        <hr class="w-75"/>
+      <hr class="w-75"/>
 
       <div class="max-w-sm rounded overflow-hidden shadow-lg">
         <h5 class="bg-green-700 px-4 text-white">

--- a/app/views/static_pages/_directions.html.erb
+++ b/app/views/static_pages/_directions.html.erb
@@ -99,12 +99,8 @@
       </div>
     <% elsif @current_enrollment.application_status == "offer accepted" %>
       <div class="m-2">
-        <% unless current_enrollment.student_packet.attached? %>
-          <p>You need to download, fill out and upload the Student Information Packet using
-          the button in the progress window to the right.</p>
-          <p class="direction_notes">The Student Packet upload is limited to files smaller than 20Mbytes. You can use an 
-            <a class="hover:underline text-blue-800" href="https://www.ilovepdf.com/compress_pdf" target="_blank">online pdf compression tool</a>
-            if your file size is larger than 20MBytes.</p> 
+        <% unless current_enrollment.camp_doc_form_completed %>
+          <p>You need to fill out the form on Camp Doc.</p>
         <% end %>
         <p>Please refer to your offer email for the payment deadline. To 
         check your account balance click the button below.</p>

--- a/app/views/static_pages/_directions.html.erb
+++ b/app/views/static_pages/_directions.html.erb
@@ -155,11 +155,12 @@
                 class: "btn btn-blue" %>
         </div>
     <% end %>
-
-    <p class="direction_notes"> Watch the progress window at the right
-      to track the status of your application materials. You will receive an
-      email with instructions for any additional steps that are required.
-    </p>
+    <div class="m-2">
+      <p class="direction_notes"> Watch the progress window at the right
+        to track the status of your application materials. You will receive an
+        email with instructions for any additional steps that are required.
+      </p>
+    </div>
   <% end %>
 
 <% else %>

--- a/app/views/static_pages/_directions.html.erb
+++ b/app/views/static_pages/_directions.html.erb
@@ -100,7 +100,11 @@
     <% elsif @current_enrollment.application_status == "offer accepted" %>
       <div class="m-2">
         <% unless current_enrollment.camp_doc_form_completed %>
-          <p>You need to fill out the form on Camp Doc.</p>
+          <p class="direction_notes">
+            The parent email address on file will be sent an invitation to complete health forms on Camp Doc 
+            after the balance has been paid in full. Please complete the forms as soon as possible. 
+            Enrollment will not be finalized until the health forms are completed.
+          </p>
         <% end %>
         <p>Please refer to your offer email for the payment deadline. To 
         check your account balance click the button below.</p>

--- a/db/migrate/20241113195535_add_camp_doc_form_completed_to_enrollment.rb
+++ b/db/migrate/20241113195535_add_camp_doc_form_completed_to_enrollment.rb
@@ -1,0 +1,5 @@
+class AddCampDocFormCompletedToEnrollment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :enrollments, :camp_doc_form_completed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_11_223015) do
+ActiveRecord::Schema.define(version: 2024_11_13_195535) do
 
-  create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "namespace"
     t.text "body"
     t.string "resource_type"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
-  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "activities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "camp_occurrence_id"
     t.string "description"
     t.integer "cost_cents"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["camp_occurrence_id"], name: "index_activities_on_camp_occurrence_id"
   end
 
-  create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "admins", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.integer "sign_in_count", default: 0, null: false
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
-  create_table "applicant_details", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "applicant_details", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "firstname", null: false
     t.string "middlename"
@@ -110,13 +110,14 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.string "parentemail"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "other_demographic"
     t.string "demographic_other"
     t.bigint "demographic_id"
     t.index ["demographic_id"], name: "index_applicant_details_on_demographic_id"
     t.index ["user_id"], name: "index_applicant_details_on_user_id"
   end
 
-  create_table "camp_configurations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "camp_configurations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "camp_year", null: false
     t.date "application_open", null: false
     t.date "application_close", null: false
@@ -134,7 +135,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["camp_year"], name: "index_camp_configurations_on_camp_year", unique: true
   end
 
-  create_table "camp_occurrences", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "camp_occurrences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "camp_configuration_id", null: false
     t.string "description", null: false
     t.date "begin_date", null: false
@@ -146,7 +147,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["camp_configuration_id"], name: "index_camp_occurrences_on_camp_configuration_id"
   end
 
-  create_table "campnotes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "campnotes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "note"
     t.datetime "opendate"
     t.datetime "closedate"
@@ -155,7 +156,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "course_assignments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "course_assignments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.bigint "course_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -165,7 +166,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_course_assignments_on_enrollment_id"
   end
 
-  create_table "course_preferences", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "course_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.bigint "course_id", null: false
     t.integer "ranking"
@@ -175,7 +176,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_course_preferences_on_enrollment_id"
   end
 
-  create_table "courses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "courses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "camp_occurrence_id", null: false
     t.string "title"
     t.integer "available_spaces"
@@ -187,7 +188,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["camp_occurrence_id"], name: "index_courses_on_camp_occurrence_id"
   end
 
-  create_table "demographics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "demographics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "description", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -195,7 +196,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.boolean "protected", default: false
   end
 
-  create_table "enrollment_activities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "enrollment_activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.bigint "activity_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -204,7 +205,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_enrollment_activities_on_enrollment_id"
   end
 
-  create_table "enrollments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.boolean "international", default: false, null: false
     t.string "high_school_name", null: false
@@ -229,10 +230,11 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.date "application_deadline"
     t.date "application_status_updated_on"
     t.string "uniqname"
+    t.boolean "camp_doc_form_completed", default: false
     t.index ["user_id"], name: "index_enrollments_on_user_id"
   end
 
-  create_table "faculties", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "faculties", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -249,7 +251,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["reset_password_token"], name: "index_faculties_on_reset_password_token", unique: true
   end
 
-  create_table "feedbacks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "genre"
     t.string "message"
     t.bigint "user_id"
@@ -258,7 +260,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["user_id"], name: "index_feedbacks_on_user_id"
   end
 
-  create_table "financial_aids", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "financial_aids", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.integer "amount_cents", default: 0
     t.string "source"
@@ -270,14 +272,14 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_financial_aids_on_enrollment_id"
   end
 
-  create_table "genders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "genders", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "payments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "payments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "transaction_type"
     t.string "transaction_status"
     t.string "transaction_id"
@@ -297,7 +299,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["user_id"], name: "index_payments_on_user_id"
   end
 
-  create_table "recommendations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "recommendations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.string "email", null: false
     t.string "lastname", null: false
@@ -319,7 +321,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_recommendations_on_enrollment_id"
   end
 
-  create_table "recuploads", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "recuploads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "letter"
     t.string "authorname", null: false
     t.string "studentname", null: false
@@ -329,7 +331,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["recommendation_id"], name: "index_recuploads_on_recommendation_id"
   end
 
-  create_table "rejections", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "rejections", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.text "reason"
     t.datetime "created_at", precision: 6, null: false
@@ -337,7 +339,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_rejections_on_enrollment_id"
   end
 
-  create_table "session_activities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "session_activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.bigint "camp_occurrence_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -346,7 +348,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_session_activities_on_enrollment_id"
   end
 
-  create_table "session_assignments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "session_assignments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.bigint "camp_occurrence_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -356,7 +358,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_session_assignments_on_enrollment_id"
   end
 
-  create_table "travels", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "travels", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "enrollment_id", null: false
     t.string "arrival_transport"
     t.string "arrival_carrier"
@@ -376,7 +378,7 @@ ActiveRecord::Schema.define(version: 2024_11_11_223015) do
     t.index ["enrollment_id"], name: "index_travels_on_enrollment_id"
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -27,6 +27,7 @@
 #  application_deadline          :date
 #  application_status_updated_on :date
 #  uniqname                      :string(255)
+#  camp_doc_form_completed       :boolean          default(FALSE)
 #
 FactoryBot.define do
   factory :enrollment do

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -27,6 +27,7 @@
 #  application_deadline          :date
 #  application_status_updated_on :date
 #  uniqname                      :string(255)
+#  camp_doc_form_completed       :boolean          default(FALSE)
 #
 require 'rails_helper'
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,7 @@ module.exports = {
         700: '#d70303',
         800: '#9b2c2c',
         900: '#742a2a',
+        umred: '#B51E0A',
       },
       orange: {
         100: '#fffaf0',
@@ -64,6 +65,7 @@ module.exports = {
         700: '#2f855a',
         800: '#276749',
         900: '#22543d',
+        umgreen: '#00743C',
       },
       teal: {
         100: '#e6fffa',


### PR DESCRIPTION
I deleted the student_packet mentions in the Active Admin camp configuration and enrollment forms and views. I deleted the commented code about vaccine_record and covid_test_record too.

I deleted the 'download and display' student_packet code in the User Interface's sidebox (and the hidden code for vaccine_record and covid_test_record were hidden).

To the enrollment model, I added the field camp_doc_form_completed.

camp_doc_form_completed field (checkbox) was added to the Active Adnin enrollment page - the field should be updated by admins manually.

I replaced checks @current_enrollment.student_packet.attached? with @current_enrollment.camp_doc_form_completed.

The before_update :if_camp_doc_form_completed was added to the Enrollment model to change application status to 'enrolled' if camp_doc_form_completed is checked by admins and payment.balance_due == 0

Other places where the application_status is updated to "enrolled" are the FinancialAid and Payment models and EnrollmentsController (on update) in case money (or other updates) are added to an enrollment.

The 'No Camp Doc Form' scope was added to Active Admin.

Information about Camp Doc Form/Health Forms was added to the user's sidebox and directions.

red-umred and green-umred were added to tailwind.config.js to replace red-700 and green-700 to fix contrast assessability errors in the sidebox.