### PR TITLE
Update enrollment form to use prioritized country options for high sc…

### DIFF
--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -76,7 +76,7 @@ ActiveAdmin.register Enrollment, as: 'Application' do
       f.input :high_school_state, as: :select, collection: us_states
       f.input :high_school_non_us
       f.input :high_school_postalcode
-      f.input :high_school_country
+      f.input :high_school_country, as: :select, collection: country_options_with_priority
       f.input :year_in_school, as: :select, collection: year_in_school
       f.input :anticipated_graduation_year
       f.input :room_mate_request

--- a/spec/requests/admin_applications_spec.rb
+++ b/spec/requests/admin_applications_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin applications", type: :request do
+  describe "GET /admin/applications/:id/edit" do
+    let(:admin) { create(:admin) }
+    let(:user) { create(:user, :with_applicant_detail) }
+    let(:enrollment) { create(:enrollment, user: user, high_school_country: "US") }
+
+    before do
+      sign_in admin
+    end
+
+    it "renders the edit form with a country select" do
+      get edit_admin_application_path(enrollment)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('name="enrollment[high_school_country]"')
+      expect(response.body).to include('<option selected="selected" value="US">United States of America</option>')
+    end
+  end
+end


### PR DESCRIPTION
This pull request updates the admin enrollment form to use a country select dropdown for the `high_school_country` field and adds a request spec to verify this behavior.

**Admin form improvements:**

* Updated the `high_school_country` field in the `app/admin/enrollments.rb` form to use a select dropdown with prioritized country options.

**Testing:**

* Added a request spec (`spec/requests/admin_applications_spec.rb`) to ensure the edit form renders the country select with the correct selected option.…hool country selection